### PR TITLE
Chore: Updates svg favicon background color

### DIFF
--- a/_includes/assets/js/inline.js
+++ b/_includes/assets/js/inline.js
@@ -71,11 +71,13 @@ document.addEventListener("DOMContentLoaded", function() {
     const $favicon = document.querySelector('link[rel="icon"]')
     if ($favicon !== null) {
       $favicon.href = link
+      $favicon.type = "image/png"
     } 
     else {
       $favicon = document.createElement("link")
       $favicon.rel = "icon"
       $favicon.href = link
+      $favicon.type = "image/png"
       document.head.appendChild($favicon)
     }
   }

--- a/static/img/favicon.svg
+++ b/static/img/favicon.svg
@@ -1,6 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+<svg class="favicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
 
   <style>
+    .favicon {
+      background-color: #fff;
+    }
     path { fill: #8a6cbd; }
     @media (prefers-color-scheme: dark) {
       path { fill: #ff6393; }


### PR DESCRIPTION
- Adds background-color so the "D" portion of the svg favicon appears white
- Updates theme switcher script to add the appropriate `type` when swapping out svg for png favicon