### PR TITLE
Bug: Fixes issue preventing web fonts to load

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,7 +1,0 @@
-# Supported browsers
-
-> 2%
-last 1 safari version
-last 1 ios version
-last 1 firefox version
-last 1 chromeandroid version


### PR DESCRIPTION
A `browserslistrc` file was added in the previous PR and it caused web fonts to not load. 
This PR reverts that previous addition. 